### PR TITLE
feat: use resource accounts

### DIFF
--- a/examples/blob-storage/README.md
+++ b/examples/blob-storage/README.md
@@ -25,12 +25,16 @@ The workload service account will automatically be assigned the necessary Azure 
 | Name | Version |
 |------|---------|
 | terraform | >= 1.3.0 |
+| azuread | ~> 2.47 |
+| azurerm | ~> 3.91 |
 | humanitec | ~> 1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
+| azuread | ~> 2.47 |
+| azurerm | ~> 3.91 |
 | humanitec | ~> 1.0 |
 
 ## Modules
@@ -52,7 +56,12 @@ The workload service account will automatically be assigned the necessary Azure 
 
 | Name | Type |
 |------|------|
+| [azuread_application.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application) | resource |
+| [azuread_service_principal.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal) | resource |
+| [azuread_service_principal_password.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal_password) | resource |
+| [azurerm_role_assignment.resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [humanitec_application.example](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/application) | resource |
+| [humanitec_resource_account.humanitec_provisioner](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_account) | resource |
 | [humanitec_resource_definition_criteria.blob_storage](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.blob_storage_admin](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.blob_storage_reader](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
@@ -63,17 +72,15 @@ The workload service account will automatically be assigned the necessary Azure 
 | [humanitec_resource_definition_criteria.role_definition_admin](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.role_definition_reader](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.workload](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
+| [azurerm_resource_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | aks\_cluster\_issuer\_url | AKS OIDC Issuer URL | `string` | n/a | yes |
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
 | resource\_group\_name | Specifies the Name of the Resource Group within which created resources will reside. | `string` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
 | account\_replication\_type | Defines the type of replication to use for this storage account. | `string` | `"GRS"` | no |
 | account\_tier | Defines the Tier to use for this storage account. | `string` | `"Standard"` | no |
 | container\_access\_type | The Access Level configured for this Container. | `string` | `"private"` | no |

--- a/examples/blob-storage/main.tf
+++ b/examples/blob-storage/main.tf
@@ -1,3 +1,41 @@
+# Service principal used by Humanitec to provision resources
+data "azurerm_resource_group" "main" {
+  name = var.resource_group_name
+}
+
+resource "azuread_application" "humanitec_provisioner" {
+  display_name = var.name
+}
+
+resource "azuread_service_principal" "humanitec_provisioner" {
+  client_id = azuread_application.humanitec_provisioner.client_id
+}
+
+resource "azuread_service_principal_password" "humanitec_provisioner" {
+  service_principal_id = azuread_service_principal.humanitec_provisioner.object_id
+}
+
+resource "azurerm_role_assignment" "resource_group" {
+  scope                = data.azurerm_resource_group.main.id
+  role_definition_name = "Contributor"
+  principal_id         = azuread_service_principal.humanitec_provisioner.object_id
+}
+
+resource "humanitec_resource_account" "humanitec_provisioner" {
+  id   = var.name
+  name = var.name
+  type = "azure"
+
+  credentials = jsonencode({
+    "appId" : azuread_service_principal.humanitec_provisioner.client_id,
+    "displayName" : azuread_application.humanitec_provisioner.display_name,
+    "password" : azuread_service_principal_password.humanitec_provisioner.value,
+    "tenant" : azuread_service_principal.humanitec_provisioner.application_tenant_id
+  })
+}
+
+# Example application and resource definition criteria
+
 resource "humanitec_application" "example" {
   id   = var.name
   name = var.name
@@ -25,9 +63,8 @@ module "blob_storage" {
 
   resource_packs_azure_url = var.resource_packs_azure_url
   resource_packs_azure_rev = var.resource_packs_azure_rev
-  client_id                = var.client_id
-  client_secret            = var.client_secret
-  tenant_id                = var.tenant_id
+  append_logs_to_error     = true
+  driver_account           = humanitec_resource_account.humanitec_provisioner.id
   subscription_id          = var.subscription_id
   resource_group_name      = var.resource_group_name
   prefix                   = var.prefix
@@ -136,11 +173,9 @@ module "federated_identity" {
 
   resource_packs_azure_url = var.resource_packs_azure_url
   resource_packs_azure_rev = var.resource_packs_azure_rev
-
-  client_id       = var.client_id
-  client_secret   = var.client_secret
-  tenant_id       = var.tenant_id
-  subscription_id = var.subscription_id
+  append_logs_to_error     = true
+  driver_account           = humanitec_resource_account.humanitec_provisioner.id
+  subscription_id          = var.subscription_id
 
   prefix = var.prefix
 
@@ -161,11 +196,9 @@ module "managed_identity" {
 
   resource_packs_azure_url = var.resource_packs_azure_url
   resource_packs_azure_rev = var.resource_packs_azure_rev
-
-  client_id       = var.client_id
-  client_secret   = var.client_secret
-  tenant_id       = var.tenant_id
-  subscription_id = var.subscription_id
+  append_logs_to_error     = true
+  driver_account           = humanitec_resource_account.humanitec_provisioner.id
+  subscription_id          = var.subscription_id
 
   prefix              = var.prefix
   resource_group_name = var.resource_group_name
@@ -181,11 +214,9 @@ module "role_assignment" {
 
   resource_packs_azure_url = var.resource_packs_azure_url
   resource_packs_azure_rev = var.resource_packs_azure_rev
-
-  client_id       = var.client_id
-  client_secret   = var.client_secret
-  tenant_id       = var.tenant_id
-  subscription_id = var.subscription_id
+  append_logs_to_error     = true
+  driver_account           = humanitec_resource_account.humanitec_provisioner.id
+  subscription_id          = var.subscription_id
 
   prefix              = var.prefix
   role_definition_ids = "$${resources.workload>azure-role-definition.outputs.id}"

--- a/examples/blob-storage/providers.tf
+++ b/examples/blob-storage/providers.tf
@@ -1,5 +1,13 @@
 terraform {
   required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 2.47"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.91"
+    }
     humanitec = {
       source  = "humanitec/humanitec"
       version = "~> 1.0"
@@ -9,4 +17,14 @@ terraform {
   required_version = ">= 1.3.0"
 }
 
-provider "humanitec" {}
+provider "humanitec" {
+}
+
+provider "azuread" {
+}
+
+provider "azurerm" {
+  features {}
+
+  subscription_id = var.subscription_id
+}

--- a/examples/blob-storage/terraform.tfvars.example
+++ b/examples/blob-storage/terraform.tfvars.example
@@ -8,12 +8,6 @@ account_tier = "Standard"
 # AKS OIDC Issuer URL
 aks_cluster_issuer_url = ""
 
-# The Client ID which should be used.
-client_id = ""
-
-# The Client Secret which should be used.
-client_secret = ""
-
 # The Access Level configured for this Container.
 container_access_type = "private"
 
@@ -37,6 +31,3 @@ resource_packs_azure_url = "https://github.com/humanitec-architecture/resource-p
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""

--- a/examples/blob-storage/variables.tf
+++ b/examples/blob-storage/variables.tf
@@ -10,21 +10,6 @@ variable "resource_packs_azure_rev" {
   default     = "refs/heads/main"
 }
 
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
-}
-
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
-  type        = string
-}
-
 variable "subscription_id" {
   description = "The Subscription ID which should be used."
   type        = string

--- a/examples/dns/README.md
+++ b/examples/dns/README.md
@@ -18,12 +18,16 @@ resources:
 | Name | Version |
 |------|---------|
 | terraform | >= 1.3.0 |
+| azuread | ~> 2.47 |
+| azurerm | ~> 3.91 |
 | humanitec | ~> 1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
+| azuread | ~> 2.47 |
+| azurerm | ~> 3.91 |
 | humanitec | ~> 1.0 |
 
 ## Modules
@@ -36,19 +40,22 @@ resources:
 
 | Name | Type |
 |------|------|
+| [azuread_application.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application) | resource |
+| [azuread_service_principal.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal) | resource |
+| [azuread_service_principal_password.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal_password) | resource |
+| [azurerm_role_assignment.resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [humanitec_application.example](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/application) | resource |
+| [humanitec_resource_account.humanitec_provisioner](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_account) | resource |
 | [humanitec_resource_definition_criteria.dns](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
+| [azurerm_resource_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
 | dns\_zone | The id of the hosted zone in which this record set will reside. | `string` | n/a | yes |
 | resource\_group\_name | Specifies the Name of the Resource Group within which this dns will reside. | `string` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
 | name | Name of the example application. | `string` | `"hum-rp-dns-example"` | no |
 | prefix | Prefix of the created resources | `string` | `"hum-rp-dns-ex-"` | no |
 | resource\_packs\_azure\_rev | Azure Resource Pack git branch. | `string` | `"refs/heads/main"` | no |

--- a/examples/dns/main.tf
+++ b/examples/dns/main.tf
@@ -1,3 +1,40 @@
+# Service principal used by Humanitec to provision resources
+data "azurerm_resource_group" "main" {
+  name = var.resource_group_name
+}
+
+resource "azuread_application" "humanitec_provisioner" {
+  display_name = var.name
+}
+
+resource "azuread_service_principal" "humanitec_provisioner" {
+  client_id = azuread_application.humanitec_provisioner.client_id
+}
+
+resource "azuread_service_principal_password" "humanitec_provisioner" {
+  service_principal_id = azuread_service_principal.humanitec_provisioner.object_id
+}
+
+resource "azurerm_role_assignment" "resource_group" {
+  scope                = data.azurerm_resource_group.main.id
+  role_definition_name = "Contributor"
+  principal_id         = azuread_service_principal.humanitec_provisioner.object_id
+}
+
+resource "humanitec_resource_account" "humanitec_provisioner" {
+  id   = var.name
+  name = var.name
+  type = "azure"
+
+  credentials = jsonencode({
+    "appId" : azuread_service_principal.humanitec_provisioner.client_id,
+    "displayName" : azuread_application.humanitec_provisioner.display_name,
+    "password" : azuread_service_principal_password.humanitec_provisioner.value,
+    "tenant" : azuread_service_principal.humanitec_provisioner.application_tenant_id
+  })
+}
+
+# Example application and resource definition criteria
 resource "humanitec_application" "example" {
   id   = var.name
   name = var.name
@@ -9,9 +46,8 @@ module "dns" {
   prefix                   = var.prefix
   resource_packs_azure_url = var.resource_packs_azure_url
   resource_packs_azure_rev = var.resource_packs_azure_rev
-  client_id                = var.client_id
-  client_secret            = var.client_secret
-  tenant_id                = var.tenant_id
+  append_logs_to_error     = true
+  driver_account           = humanitec_resource_account.humanitec_provisioner.id
   subscription_id          = var.subscription_id
   dns_zone                 = var.dns_zone
   resource_group_name      = var.resource_group_name

--- a/examples/dns/providers.tf
+++ b/examples/dns/providers.tf
@@ -1,5 +1,13 @@
 terraform {
   required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 2.47"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.91"
+    }
     humanitec = {
       source  = "humanitec/humanitec"
       version = "~> 1.0"
@@ -9,4 +17,14 @@ terraform {
   required_version = ">= 1.3.0"
 }
 
-provider "humanitec" {}
+provider "humanitec" {
+}
+
+provider "azuread" {
+}
+
+provider "azurerm" {
+  features {}
+
+  subscription_id = var.subscription_id
+}

--- a/examples/dns/terraform.tfvars.example
+++ b/examples/dns/terraform.tfvars.example
@@ -1,10 +1,4 @@
 
-# The Client ID which should be used.
-client_id = ""
-
-# The Client Secret which should be used.
-client_secret = ""
-
 # The id of the hosted zone in which this record set will reside.
 dns_zone = ""
 
@@ -25,6 +19,3 @@ resource_packs_azure_url = "https://github.com/humanitec-architecture/resource-p
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""

--- a/examples/dns/variables.tf
+++ b/examples/dns/variables.tf
@@ -22,21 +22,6 @@ variable "resource_packs_azure_rev" {
   default     = "refs/heads/main"
 }
 
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
-}
-
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
-  type        = string
-}
-
 variable "subscription_id" {
   description = "The Subscription ID which should be used."
   type        = string

--- a/examples/mysql/README.md
+++ b/examples/mysql/README.md
@@ -18,12 +18,16 @@ resources:
 | Name | Version |
 |------|---------|
 | terraform | >= 1.3.0 |
+| azuread | ~> 2.47 |
+| azurerm | ~> 3.91 |
 | humanitec | ~> 1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
+| azuread | ~> 2.47 |
+| azurerm | ~> 3.91 |
 | humanitec | ~> 1.0 |
 
 ## Modules
@@ -36,8 +40,14 @@ resources:
 
 | Name | Type |
 |------|------|
+| [azuread_application.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application) | resource |
+| [azuread_service_principal.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal) | resource |
+| [azuread_service_principal_password.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal_password) | resource |
+| [azurerm_role_assignment.resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [humanitec_application.example](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/application) | resource |
+| [humanitec_resource_account.humanitec_provisioner](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_account) | resource |
 | [humanitec_resource_definition_criteria.mysql](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
+| [azurerm_resource_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 
@@ -45,12 +55,9 @@ resources:
 |------|-------------|------|---------|:--------:|
 | administrator\_login | The Administrator login for the MySQL Server. | `string` | n/a | yes |
 | administrator\_login\_password | The Password associated with the administrator\_login for the MySQL Server. | `string` | n/a | yes |
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
 | resource\_group\_name | Specifies the Name of the Resource Group within which this database will reside. | `string` | n/a | yes |
 | subnet\_name | The name of the Subnet from which Private IP Addresses will be allocated for this Private Endpoint. | `string` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
 | virtual\_network\_name | The name of the virtual network where Private Endpoint will be allocated. | `string` | n/a | yes |
 | virtual\_network\_resource\_group\_name | Specifies the Name of the Resource Group within which the Private Endpoint should exist. | `string` | n/a | yes |
 | name | Name of the example application. | `string` | `"hum-rp-mysql-example"` | no |

--- a/examples/mysql/main.tf
+++ b/examples/mysql/main.tf
@@ -1,3 +1,40 @@
+# Service principal used by Humanitec to provision resources
+data "azurerm_resource_group" "main" {
+  name = var.resource_group_name
+}
+
+resource "azuread_application" "humanitec_provisioner" {
+  display_name = var.name
+}
+
+resource "azuread_service_principal" "humanitec_provisioner" {
+  client_id = azuread_application.humanitec_provisioner.client_id
+}
+
+resource "azuread_service_principal_password" "humanitec_provisioner" {
+  service_principal_id = azuread_service_principal.humanitec_provisioner.object_id
+}
+
+resource "azurerm_role_assignment" "resource_group" {
+  scope                = data.azurerm_resource_group.main.id
+  role_definition_name = "Contributor"
+  principal_id         = azuread_service_principal.humanitec_provisioner.object_id
+}
+
+resource "humanitec_resource_account" "humanitec_provisioner" {
+  id   = var.name
+  name = var.name
+  type = "azure"
+
+  credentials = jsonencode({
+    "appId" : azuread_service_principal.humanitec_provisioner.client_id,
+    "displayName" : azuread_application.humanitec_provisioner.display_name,
+    "password" : azuread_service_principal_password.humanitec_provisioner.value,
+    "tenant" : azuread_service_principal.humanitec_provisioner.application_tenant_id
+  })
+}
+
+# Example application and resource definition criteria
 resource "humanitec_application" "example" {
   id   = var.name
   name = var.name
@@ -9,9 +46,8 @@ module "mysql" {
   prefix                              = var.prefix
   resource_packs_azure_url            = var.resource_packs_azure_url
   resource_packs_azure_rev            = var.resource_packs_azure_rev
-  client_id                           = var.client_id
-  client_secret                       = var.client_secret
-  tenant_id                           = var.tenant_id
+  append_logs_to_error                = true
+  driver_account                      = humanitec_resource_account.humanitec_provisioner.id
   subscription_id                     = var.subscription_id
   resource_group_name                 = var.resource_group_name
   administrator_login                 = var.administrator_login

--- a/examples/mysql/providers.tf
+++ b/examples/mysql/providers.tf
@@ -1,5 +1,13 @@
 terraform {
   required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 2.47"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.91"
+    }
     humanitec = {
       source  = "humanitec/humanitec"
       version = "~> 1.0"
@@ -9,4 +17,14 @@ terraform {
   required_version = ">= 1.3.0"
 }
 
-provider "humanitec" {}
+provider "humanitec" {
+}
+
+provider "azuread" {
+}
+
+provider "azurerm" {
+  features {}
+
+  subscription_id = var.subscription_id
+}

--- a/examples/mysql/terraform.tfvars.example
+++ b/examples/mysql/terraform.tfvars.example
@@ -5,12 +5,6 @@ administrator_login = ""
 # The Password associated with the administrator_login for the MySQL Server.
 administrator_login_password = ""
 
-# The Client ID which should be used.
-client_id = ""
-
-# The Client Secret which should be used.
-client_secret = ""
-
 # Name of the example application.
 name = "hum-rp-mysql-example"
 
@@ -31,9 +25,6 @@ subnet_name = ""
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""
 
 # The name of the virtual network where Private Endpoint will be allocated.
 virtual_network_name = ""

--- a/examples/mysql/variables.tf
+++ b/examples/mysql/variables.tf
@@ -22,21 +22,6 @@ variable "resource_packs_azure_rev" {
   default     = "refs/heads/main"
 }
 
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
-}
-
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
-  type        = string
-}
-
 variable "subscription_id" {
   description = "The Subscription ID which should be used."
   type        = string

--- a/examples/postgres/main.tf
+++ b/examples/postgres/main.tf
@@ -1,4 +1,11 @@
 # Service principal used by Humanitec to provision resources
+data "azurerm_resource_group" "resource" {
+  name = var.resource_group_name
+}
+
+data "azurerm_resource_group" "workload" {
+  name = var.workload_resource_group_name
+}
 
 resource "azuread_application" "humanitec_provisioner" {
   display_name = var.name
@@ -48,14 +55,6 @@ locals {
 resource "humanitec_application" "example" {
   id   = var.name
   name = var.name
-}
-
-data "azurerm_resource_group" "resource" {
-  name = var.resource_group_name
-}
-
-data "azurerm_resource_group" "workload" {
-  name = var.workload_resource_group_name
 }
 
 module "postgres_instance" {

--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -18,12 +18,16 @@ resources:
 | Name | Version |
 |------|---------|
 | terraform | >= 1.3.0 |
+| azuread | ~> 2.47 |
+| azurerm | ~> 3.91 |
 | humanitec | ~> 1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
+| azuread | ~> 2.47 |
+| azurerm | ~> 3.91 |
 | humanitec | ~> 1.0 |
 
 ## Modules
@@ -36,18 +40,21 @@ resources:
 
 | Name | Type |
 |------|------|
+| [azuread_application.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application) | resource |
+| [azuread_service_principal.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal) | resource |
+| [azuread_service_principal_password.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal_password) | resource |
+| [azurerm_role_assignment.resource_group_workload](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [humanitec_application.example](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/application) | resource |
+| [humanitec_resource_account.humanitec_provisioner](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_account) | resource |
 | [humanitec_resource_definition_criteria.redis](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
+| [azurerm_resource_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
 | resource\_group\_name | Specifies the Name of the Resource Group within which this database will reside. | `string` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
 | name | Specifies the Name for created application. | `string` | `"hum-rp-redis-example"` | no |
 | resource\_packs\_azure\_rev | Azure Resource Pack git branch. | `string` | `"refs/heads/main"` | no |
 | resource\_packs\_azure\_url | Azure Resource Pack git url. | `string` | `"https://github.com/humanitec-architecture/resource-packs-azure.git"` | no |

--- a/examples/redis/main.tf
+++ b/examples/redis/main.tf
@@ -1,3 +1,40 @@
+# Service principal used by Humanitec to provision resources
+data "azurerm_resource_group" "main" {
+  name = var.resource_group_name
+}
+
+resource "azuread_application" "humanitec_provisioner" {
+  display_name = var.name
+}
+
+resource "azuread_service_principal" "humanitec_provisioner" {
+  client_id = azuread_application.humanitec_provisioner.client_id
+}
+
+resource "azuread_service_principal_password" "humanitec_provisioner" {
+  service_principal_id = azuread_service_principal.humanitec_provisioner.object_id
+}
+
+resource "azurerm_role_assignment" "resource_group_workload" {
+  scope                = data.azurerm_resource_group.main.id
+  role_definition_name = "Contributor"
+  principal_id         = azuread_service_principal.humanitec_provisioner.object_id
+}
+
+resource "humanitec_resource_account" "humanitec_provisioner" {
+  id   = var.name
+  name = var.name
+  type = "azure"
+
+  credentials = jsonencode({
+    "appId" : azuread_service_principal.humanitec_provisioner.client_id,
+    "displayName" : azuread_application.humanitec_provisioner.display_name,
+    "password" : azuread_service_principal_password.humanitec_provisioner.value,
+    "tenant" : azuread_service_principal.humanitec_provisioner.application_tenant_id
+  })
+}
+
+# Example application and resource definition criteria
 resource "humanitec_application" "example" {
   id   = var.name
   name = var.name
@@ -8,9 +45,8 @@ module "dns" {
 
   resource_packs_azure_url = var.resource_packs_azure_url
   resource_packs_azure_rev = var.resource_packs_azure_rev
-  client_id                = var.client_id
-  client_secret            = var.client_secret
-  tenant_id                = var.tenant_id
+  append_logs_to_error     = true
+  driver_account           = humanitec_resource_account.humanitec_provisioner.id
   subscription_id          = var.subscription_id
   resource_group_name      = var.resource_group_name
 }

--- a/examples/redis/providers.tf
+++ b/examples/redis/providers.tf
@@ -1,5 +1,13 @@
 terraform {
   required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 2.47"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.91"
+    }
     humanitec = {
       source  = "humanitec/humanitec"
       version = "~> 1.0"
@@ -9,4 +17,14 @@ terraform {
   required_version = ">= 1.3.0"
 }
 
-provider "humanitec" {}
+provider "humanitec" {
+}
+
+provider "azuread" {
+}
+
+provider "azurerm" {
+  features {}
+
+  subscription_id = var.subscription_id
+}

--- a/examples/redis/terraform.tfvars.example
+++ b/examples/redis/terraform.tfvars.example
@@ -1,10 +1,4 @@
 
-# The Client ID which should be used.
-client_id = ""
-
-# The Client Secret which should be used.
-client_secret = ""
-
 # Specifies the Name for created application.
 name = "hum-rp-redis-example"
 
@@ -19,6 +13,3 @@ resource_packs_azure_url = "https://github.com/humanitec-architecture/resource-p
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""

--- a/examples/redis/variables.tf
+++ b/examples/redis/variables.tf
@@ -10,21 +10,6 @@ variable "resource_packs_azure_rev" {
   default     = "refs/heads/main"
 }
 
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
-}
-
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
-  type        = string
-}
-
 variable "subscription_id" {
   description = "The Subscription ID which should be used."
   type        = string

--- a/examples/service-bus/README.md
+++ b/examples/service-bus/README.md
@@ -25,12 +25,16 @@ The workload service account will automatically be assigned the necessary roles.
 | Name | Version |
 |------|---------|
 | terraform | >= 1.3.0 |
+| azuread | ~> 2.47 |
+| azurerm | ~> 3.91 |
 | humanitec | ~> 1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
+| azuread | ~> 2.47 |
+| azurerm | ~> 3.91 |
 | humanitec | ~> 1.0 |
 
 ## Modules
@@ -52,7 +56,12 @@ The workload service account will automatically be assigned the necessary roles.
 
 | Name | Type |
 |------|------|
+| [azuread_application.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application) | resource |
+| [azuread_service_principal.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal) | resource |
+| [azuread_service_principal_password.humanitec_provisioner](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal_password) | resource |
+| [azurerm_role_assignment.resource_group_workload](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [humanitec_application.example](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/application) | resource |
+| [humanitec_resource_account.humanitec_provisioner](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_account) | resource |
 | [humanitec_resource_definition_criteria.federated_identity](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.k8s_service_account](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.managed_identity](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
@@ -63,17 +72,15 @@ The workload service account will automatically be assigned the necessary roles.
 | [humanitec_resource_definition_criteria.service_bus_consumer](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.service_bus_publisher](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.workload](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
+| [azurerm_resource_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | aks\_cluster\_issuer\_url | AKS OIDC Issuer URL | `string` | n/a | yes |
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
 | resource\_group\_name | Specifies the Name of the Resource Group within which created resources will reside. | `string` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
 | name | Specifies the Name for created example application. | `string` | `"hum-rp-service-bus-example"` | no |
 | prefix | Specifies the prefix used in default name for created resources. | `string` | `"hum-rp-service-bus-ex-"` | no |
 | resource\_packs\_azure\_rev | Azure Resource Pack git branch. | `string` | `"refs/heads/main"` | no |

--- a/examples/service-bus/main.tf
+++ b/examples/service-bus/main.tf
@@ -1,3 +1,40 @@
+# Service principal used by Humanitec to provision resources
+data "azurerm_resource_group" "main" {
+  name = var.resource_group_name
+}
+
+resource "azuread_application" "humanitec_provisioner" {
+  display_name = var.name
+}
+
+resource "azuread_service_principal" "humanitec_provisioner" {
+  client_id = azuread_application.humanitec_provisioner.client_id
+}
+
+resource "azuread_service_principal_password" "humanitec_provisioner" {
+  service_principal_id = azuread_service_principal.humanitec_provisioner.object_id
+}
+
+resource "azurerm_role_assignment" "resource_group_workload" {
+  scope                = data.azurerm_resource_group.main.id
+  role_definition_name = "Contributor"
+  principal_id         = azuread_service_principal.humanitec_provisioner.object_id
+}
+
+resource "humanitec_resource_account" "humanitec_provisioner" {
+  id   = var.name
+  name = var.name
+  type = "azure"
+
+  credentials = jsonencode({
+    "appId" : azuread_service_principal.humanitec_provisioner.client_id,
+    "displayName" : azuread_application.humanitec_provisioner.display_name,
+    "password" : azuread_service_principal_password.humanitec_provisioner.value,
+    "tenant" : azuread_service_principal.humanitec_provisioner.application_tenant_id
+  })
+}
+
+# Example application and resource definition criteria
 resource "humanitec_application" "example" {
   id   = var.name
   name = var.name
@@ -25,9 +62,8 @@ module "service_bus" {
 
   resource_packs_azure_url = var.resource_packs_azure_url
   resource_packs_azure_rev = var.resource_packs_azure_rev
-  client_id                = var.client_id
-  client_secret            = var.client_secret
-  tenant_id                = var.tenant_id
+  append_logs_to_error     = true
+  driver_account           = humanitec_resource_account.humanitec_provisioner.id
   subscription_id          = var.subscription_id
   resource_group_name      = var.resource_group_name
   prefix                   = var.prefix
@@ -133,11 +169,9 @@ module "federated_identity" {
 
   resource_packs_azure_url = var.resource_packs_azure_url
   resource_packs_azure_rev = var.resource_packs_azure_rev
-
-  client_id       = var.client_id
-  client_secret   = var.client_secret
-  tenant_id       = var.tenant_id
-  subscription_id = var.subscription_id
+  append_logs_to_error     = true
+  driver_account           = humanitec_resource_account.humanitec_provisioner.id
+  subscription_id          = var.subscription_id
 
   prefix = var.prefix
 
@@ -158,11 +192,9 @@ module "managed_identity" {
 
   resource_packs_azure_url = var.resource_packs_azure_url
   resource_packs_azure_rev = var.resource_packs_azure_rev
-
-  client_id       = var.client_id
-  client_secret   = var.client_secret
-  tenant_id       = var.tenant_id
-  subscription_id = var.subscription_id
+  append_logs_to_error     = true
+  driver_account           = humanitec_resource_account.humanitec_provisioner.id
+  subscription_id          = var.subscription_id
 
   prefix              = var.prefix
   resource_group_name = var.resource_group_name
@@ -178,11 +210,9 @@ module "role_assignment" {
 
   resource_packs_azure_url = var.resource_packs_azure_url
   resource_packs_azure_rev = var.resource_packs_azure_rev
-
-  client_id       = var.client_id
-  client_secret   = var.client_secret
-  tenant_id       = var.tenant_id
-  subscription_id = var.subscription_id
+  append_logs_to_error     = true
+  driver_account           = humanitec_resource_account.humanitec_provisioner.id
+  subscription_id          = var.subscription_id
 
   prefix              = var.prefix
   role_definition_ids = "$${resources.workload>azure-role-definition.outputs.id}"

--- a/examples/service-bus/providers.tf
+++ b/examples/service-bus/providers.tf
@@ -1,5 +1,13 @@
 terraform {
   required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 2.47"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.91"
+    }
     humanitec = {
       source  = "humanitec/humanitec"
       version = "~> 1.0"
@@ -9,4 +17,14 @@ terraform {
   required_version = ">= 1.3.0"
 }
 
-provider "humanitec" {}
+provider "humanitec" {
+}
+
+provider "azuread" {
+}
+
+provider "azurerm" {
+  features {}
+
+  subscription_id = var.subscription_id
+}

--- a/examples/service-bus/terraform.tfvars.example
+++ b/examples/service-bus/terraform.tfvars.example
@@ -2,12 +2,6 @@
 # AKS OIDC Issuer URL
 aks_cluster_issuer_url = ""
 
-# The Client ID which should be used.
-client_id = ""
-
-# The Client Secret which should be used.
-client_secret = ""
-
 # Specifies the Name for created example application.
 name = "hum-rp-service-bus-example"
 
@@ -28,6 +22,3 @@ sku = "Standard"
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""

--- a/examples/service-bus/variables.tf
+++ b/examples/service-bus/variables.tf
@@ -10,21 +10,6 @@ variable "resource_packs_azure_rev" {
   default     = "refs/heads/main"
 }
 
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
-}
-
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
-  type        = string
-}
-
 variable "subscription_id" {
   description = "The Subscription ID which should be used."
   type        = string

--- a/humanitec-resource-defs/azure-blob/basic/README.md
+++ b/humanitec-resource-defs/azure-blob/basic/README.md
@@ -22,14 +22,13 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
 | container\_name | The name of the Container which should be created within the Storage Account. | `string` | n/a | yes |
+| driver\_account | The ID of the Resource Account which should be used. | `string` | n/a | yes |
 | resource\_group\_name | Specifies the Name of the Resource Group within which created resources will reside. | `string` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
 | account\_replication\_type | Defines the type of replication to use for this storage account. | `string` | `"GRS"` | no |
 | account\_tier | Defines the Tier to use for this storage account. | `string` | `"Standard"` | no |
+| append\_logs\_to\_error | Append Terraform logs to error messages. | `bool` | `false` | no |
 | container\_access\_type | The Access Level configured for this Container. | `string` | `"private"` | no |
 | name | Specifies the Name for created resources. (Leave empty for the default one) | `string` | `""` | no |
 | prefix | Specifies the prefix used in default name for created resources. | `string` | `"hum-rp-blob-storage-ex-"` | no |

--- a/humanitec-resource-defs/azure-blob/basic/main.tf
+++ b/humanitec-resource-defs/azure-blob/basic/main.tf
@@ -4,14 +4,8 @@ resource "humanitec_resource_definition" "main" {
   name        = "${var.prefix}azure-blob-storage-basic"
   type        = "azure-blob"
 
+  driver_account = var.driver_account
   driver_inputs = {
-    secrets_string = jsonencode({
-      variables = {
-        client_id     = var.client_id
-        client_secret = var.client_secret
-      }
-    })
-
     values_string = jsonencode({
       source = {
         path = "modules/azure-blob/basic"
@@ -19,12 +13,21 @@ resource "humanitec_resource_definition" "main" {
         url  = var.resource_packs_azure_url
       }
 
+      append_logs_to_error = var.append_logs_to_error
+
+      credentials_config = {
+        environment = {
+          ARM_CLIENT_ID     = "appId"
+          ARM_CLIENT_SECRET = "password"
+          ARM_TENANT_ID     = "tenant"
+        }
+      }
+
       variables = {
         res_id = "$${context.res.id}"
         app_id = "$${context.app.id}"
         env_id = "$${context.env.id}"
 
-        tenant_id                = var.tenant_id
         subscription_id          = var.subscription_id
         resource_group_name      = var.resource_group_name
         name                     = var.name

--- a/humanitec-resource-defs/azure-blob/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/azure-blob/basic/terraform.tfvars.example
@@ -5,17 +5,17 @@ account_replication_type = "GRS"
 # Defines the Tier to use for this storage account.
 account_tier = "Standard"
 
-# The Client ID which should be used.
-client_id = ""
-
-# The Client Secret which should be used.
-client_secret = ""
+# Append Terraform logs to error messages.
+append_logs_to_error = false
 
 # The Access Level configured for this Container.
 container_access_type = "private"
 
 # The name of the Container which should be created within the Storage Account.
 container_name = ""
+
+# The ID of the Resource Account which should be used.
+driver_account = ""
 
 # Specifies the Name for created resources. (Leave empty for the default one)
 name = ""
@@ -34,6 +34,3 @@ resource_packs_azure_url = "https://github.com/humanitec-architecture/resource-p
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""

--- a/humanitec-resource-defs/azure-blob/basic/variables.tf
+++ b/humanitec-resource-defs/azure-blob/basic/variables.tf
@@ -10,18 +10,14 @@ variable "resource_packs_azure_rev" {
   default     = "refs/heads/main"
 }
 
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
+variable "append_logs_to_error" {
+  description = "Append Terraform logs to error messages."
+  type        = bool
+  default     = false
 }
 
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
+variable "driver_account" {
+  description = "The ID of the Resource Account which should be used."
   type        = string
 }
 

--- a/humanitec-resource-defs/azure-federated-identity/basic/README.md
+++ b/humanitec-resource-defs/azure-federated-identity/basic/README.md
@@ -23,14 +23,13 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | audience | Specifies the audience for this Federated Identity Credential. | `set(string)` | n/a | yes |
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
+| driver\_account | The ID of the Resource Account which should be used. | `string` | n/a | yes |
 | issuer | Specifies the issuer of this Federated Identity Credential. | `string` | n/a | yes |
 | parent\_id | Specifies parent ID of User Assigned Identity for this Federated Identity Credential. | `string` | n/a | yes |
 | resource\_group\_name | Specifies the Name of the Resource Group within which created resources will reside. | `string` | n/a | yes |
 | subject | Specifies the subject for this Federated Identity Credential. | `string` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
+| append\_logs\_to\_error | Append Terraform logs to error messages. | `bool` | `false` | no |
 | name | Specifies the Name for created resources. (Leave empty for the default one) | `string` | `""` | no |
 | prefix | Specifies the prefix used in default name for created resources. | `string` | `"hum-rp-service-bus-ex-"` | no |
 | resource\_packs\_azure\_rev | Azure Resource Pack git branch. | `string` | `"refs/heads/main"` | no |

--- a/humanitec-resource-defs/azure-federated-identity/basic/main.tf
+++ b/humanitec-resource-defs/azure-federated-identity/basic/main.tf
@@ -4,19 +4,23 @@ resource "humanitec_resource_definition" "main" {
   name        = "${var.prefix}federated-identity-basic"
   type        = "azure-federated-identity"
 
+  driver_account = var.driver_account
   driver_inputs = {
-    secrets_string = jsonencode({
-      variables = {
-        client_id     = var.client_id
-        client_secret = var.client_secret
-      }
-    })
-
     values_string = jsonencode({
       source = {
         path = "modules/azure-federated-identity/basic"
         rev  = var.resource_packs_azure_rev
         url  = var.resource_packs_azure_url
+      }
+
+      append_logs_to_error = var.append_logs_to_error
+
+      credentials_config = {
+        environment = {
+          ARM_CLIENT_ID     = "appId"
+          ARM_CLIENT_SECRET = "password"
+          ARM_TENANT_ID     = "tenant"
+        }
       }
 
       variables = {
@@ -25,7 +29,6 @@ resource "humanitec_resource_definition" "main" {
         env_id = "$${context.env.id}"
 
         name                = var.name
-        tenant_id           = var.tenant_id
         subscription_id     = var.subscription_id
         prefix              = var.prefix
         resource_group_name = var.resource_group_name

--- a/humanitec-resource-defs/azure-federated-identity/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/azure-federated-identity/basic/terraform.tfvars.example
@@ -1,12 +1,12 @@
 
+# Append Terraform logs to error messages.
+append_logs_to_error = false
+
 # Specifies the audience for this Federated Identity Credential.
 audience = ""
 
-# The Client ID which should be used.
-client_id = ""
-
-# The Client Secret which should be used.
-client_secret = ""
+# The ID of the Resource Account which should be used.
+driver_account = ""
 
 # Specifies the issuer of this Federated Identity Credential.
 issuer = ""
@@ -34,6 +34,3 @@ subject = ""
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""

--- a/humanitec-resource-defs/azure-federated-identity/basic/variables.tf
+++ b/humanitec-resource-defs/azure-federated-identity/basic/variables.tf
@@ -10,18 +10,14 @@ variable "resource_packs_azure_rev" {
   default     = "refs/heads/main"
 }
 
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
+variable "append_logs_to_error" {
+  description = "Append Terraform logs to error messages."
+  type        = bool
+  default     = false
 }
 
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
+variable "driver_account" {
+  description = "The ID of the Resource Account which should be used."
   type        = string
 }
 

--- a/humanitec-resource-defs/azure-managed-identity/basic/README.md
+++ b/humanitec-resource-defs/azure-managed-identity/basic/README.md
@@ -22,11 +22,10 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
+| driver\_account | The ID of the Resource Account which should be used. | `string` | n/a | yes |
 | resource\_group\_name | Specifies the Name of the Resource Group within which created resources will reside. | `string` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
+| append\_logs\_to\_error | Append Terraform logs to error messages. | `bool` | `false` | no |
 | name | Specifies the Name for created resources. (Leave empty for the default one) | `string` | `""` | no |
 | prefix | Specifies the prefix used in default name for created resources. | `string` | `"hum-rp-service-bus-ex-"` | no |
 | resource\_packs\_azure\_rev | Azure Resource Pack git branch. | `string` | `"refs/heads/main"` | no |

--- a/humanitec-resource-defs/azure-managed-identity/basic/main.tf
+++ b/humanitec-resource-defs/azure-managed-identity/basic/main.tf
@@ -4,19 +4,23 @@ resource "humanitec_resource_definition" "main" {
   name        = "${var.prefix}managed-identity-basic"
   type        = "azure-managed-identity"
 
+  driver_account = var.driver_account
   driver_inputs = {
-    secrets_string = jsonencode({
-      variables = {
-        client_id     = var.client_id
-        client_secret = var.client_secret
-      }
-    })
-
     values_string = jsonencode({
       source = {
         path = "modules/azure-managed-identity/basic"
         rev  = var.resource_packs_azure_rev
         url  = var.resource_packs_azure_url
+      }
+
+      append_logs_to_error = var.append_logs_to_error
+
+      credentials_config = {
+        environment = {
+          ARM_CLIENT_ID     = "appId"
+          ARM_CLIENT_SECRET = "password"
+          ARM_TENANT_ID     = "tenant"
+        }
       }
 
       variables = {
@@ -25,7 +29,6 @@ resource "humanitec_resource_definition" "main" {
         env_id = "$${context.env.id}"
 
         name                = var.name
-        tenant_id           = var.tenant_id
         subscription_id     = var.subscription_id
         resource_group_name = var.resource_group_name
       }

--- a/humanitec-resource-defs/azure-managed-identity/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/azure-managed-identity/basic/terraform.tfvars.example
@@ -1,9 +1,9 @@
 
-# The Client ID which should be used.
-client_id = ""
+# Append Terraform logs to error messages.
+append_logs_to_error = false
 
-# The Client Secret which should be used.
-client_secret = ""
+# The ID of the Resource Account which should be used.
+driver_account = ""
 
 # Specifies the Name for created resources. (Leave empty for the default one)
 name = ""
@@ -22,6 +22,3 @@ resource_packs_azure_url = "https://github.com/humanitec-architecture/resource-p
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""

--- a/humanitec-resource-defs/azure-managed-identity/basic/variables.tf
+++ b/humanitec-resource-defs/azure-managed-identity/basic/variables.tf
@@ -10,18 +10,14 @@ variable "resource_packs_azure_rev" {
   default     = "refs/heads/main"
 }
 
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
+variable "append_logs_to_error" {
+  description = "Append Terraform logs to error messages."
+  type        = bool
+  default     = false
 }
 
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
+variable "driver_account" {
+  description = "The ID of the Resource Account which should be used."
   type        = string
 }
 

--- a/humanitec-resource-defs/azure-role-assignments/basic/README.md
+++ b/humanitec-resource-defs/azure-role-assignments/basic/README.md
@@ -22,13 +22,12 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
+| driver\_account | The ID of the Resource Account which should be used. | `string` | n/a | yes |
 | principal\_id | The ID of the Principal (User, Group or Service Principal) to assign the Role Definition to. | `string` | n/a | yes |
 | role\_definition\_ids | n/a | `any` | n/a | yes |
 | scopes | n/a | `any` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
+| append\_logs\_to\_error | Append Terraform logs to error messages. | `bool` | `false` | no |
 | name | Specifies the Name for created resources. (Leave empty for the default one) | `string` | `""` | no |
 | prefix | Specifies the prefix used in default name for created resources. | `string` | `"hum-rp-service-bus-ex-"` | no |
 | resource\_packs\_azure\_rev | Azure Resource Pack git branch. | `string` | `"refs/heads/main"` | no |

--- a/humanitec-resource-defs/azure-role-assignments/basic/main.tf
+++ b/humanitec-resource-defs/azure-role-assignments/basic/main.tf
@@ -4,19 +4,23 @@ resource "humanitec_resource_definition" "main" {
   name        = "${var.prefix}role-assignment-basic"
   type        = "azure-role-assignments"
 
+  driver_account = var.driver_account
   driver_inputs = {
-    secrets_string = jsonencode({
-      variables = {
-        client_id     = var.client_id
-        client_secret = var.client_secret
-      }
-    })
-
     values_string = jsonencode({
       source = {
         path = "modules/azure-role-assignments/basic"
         rev  = var.resource_packs_azure_rev
         url  = var.resource_packs_azure_url
+      }
+
+      append_logs_to_error = var.append_logs_to_error
+
+      credentials_config = {
+        environment = {
+          ARM_CLIENT_ID     = "appId"
+          ARM_CLIENT_SECRET = "password"
+          ARM_TENANT_ID     = "tenant"
+        }
       }
 
       variables = {
@@ -25,7 +29,6 @@ resource "humanitec_resource_definition" "main" {
         env_id = "$${context.env.id}"
 
         name                = var.name
-        tenant_id           = var.tenant_id
         subscription_id     = var.subscription_id
         prefix              = var.prefix
         role_definition_ids = var.role_definition_ids

--- a/humanitec-resource-defs/azure-role-assignments/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/azure-role-assignments/basic/terraform.tfvars.example
@@ -1,9 +1,9 @@
 
-# The Client ID which should be used.
-client_id = ""
+# Append Terraform logs to error messages.
+append_logs_to_error = false
 
-# The Client Secret which should be used.
-client_secret = ""
+# The ID of the Resource Account which should be used.
+driver_account = ""
 
 # Specifies the Name for created resources. (Leave empty for the default one)
 name = ""
@@ -25,6 +25,3 @@ scopes              = ""
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""

--- a/humanitec-resource-defs/azure-role-assignments/basic/variables.tf
+++ b/humanitec-resource-defs/azure-role-assignments/basic/variables.tf
@@ -10,18 +10,14 @@ variable "resource_packs_azure_rev" {
   default     = "refs/heads/main"
 }
 
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
+variable "append_logs_to_error" {
+  description = "Append Terraform logs to error messages."
+  type        = bool
+  default     = false
 }
 
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
+variable "driver_account" {
+  description = "The ID of the Resource Account which should be used."
   type        = string
 }
 

--- a/humanitec-resource-defs/azure-role-definition/basic/README.md
+++ b/humanitec-resource-defs/azure-role-definition/basic/README.md
@@ -23,12 +23,11 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | actions | One or more Allowed Actions. | `set(string)` | n/a | yes |
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
 | data\_actions | One or more Allowed Data Actions. | `set(string)` | n/a | yes |
+| driver\_account | The ID of the Resource Account which should be used. | `string` | n/a | yes |
 | scope | The scope at which the Role Assignment applies to. | `string` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
+| append\_logs\_to\_error | Append Terraform logs to error messages. | `bool` | `false` | no |
 | name | Specifies the Name for created resources. (Leave empty for the default one) | `string` | `""` | no |
 | prefix | Specifies the prefix used in default name for created resources. | `string` | `"hum-rp-service-bus-ex-"` | no |
 | resource\_packs\_azure\_rev | Azure Resource Pack git branch. | `string` | `"refs/heads/main"` | no |

--- a/humanitec-resource-defs/azure-role-definition/basic/main.tf
+++ b/humanitec-resource-defs/azure-role-definition/basic/main.tf
@@ -4,19 +4,23 @@ resource "humanitec_resource_definition" "main" {
   name        = "${var.prefix}role-definition-basic"
   type        = "azure-role-definition"
 
+  driver_account = var.driver_account
   driver_inputs = {
-    secrets_string = jsonencode({
-      variables = {
-        client_id     = var.client_id
-        client_secret = var.client_secret
-      }
-    })
-
     values_string = jsonencode({
       source = {
         path = "modules/azure-role-definition/basic"
         rev  = var.resource_packs_azure_rev
         url  = var.resource_packs_azure_url
+      }
+
+      append_logs_to_error = var.append_logs_to_error
+
+      credentials_config = {
+        environment = {
+          ARM_CLIENT_ID     = "appId"
+          ARM_CLIENT_SECRET = "password"
+          ARM_TENANT_ID     = "tenant"
+        }
       }
 
       variables = {
@@ -26,7 +30,6 @@ resource "humanitec_resource_definition" "main" {
         prefix = var.prefix
 
         name            = var.name
-        tenant_id       = var.tenant_id
         subscription_id = var.subscription_id
         prefix          = var.prefix
         scope           = var.scope

--- a/humanitec-resource-defs/azure-role-definition/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/azure-role-definition/basic/terraform.tfvars.example
@@ -2,14 +2,14 @@
 # One or more Allowed Actions.
 actions = ""
 
-# The Client ID which should be used.
-client_id = ""
-
-# The Client Secret which should be used.
-client_secret = ""
+# Append Terraform logs to error messages.
+append_logs_to_error = false
 
 # One or more Allowed Data Actions.
 data_actions = ""
+
+# The ID of the Resource Account which should be used.
+driver_account = ""
 
 # Specifies the Name for created resources. (Leave empty for the default one)
 name = ""
@@ -28,6 +28,3 @@ scope = ""
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""

--- a/humanitec-resource-defs/azure-role-definition/basic/variables.tf
+++ b/humanitec-resource-defs/azure-role-definition/basic/variables.tf
@@ -10,18 +10,14 @@ variable "resource_packs_azure_rev" {
   default     = "refs/heads/main"
 }
 
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
+variable "append_logs_to_error" {
+  description = "Append Terraform logs to error messages."
+  type        = bool
+  default     = false
 }
 
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
+variable "driver_account" {
+  description = "The ID of the Resource Account which should be used."
   type        = string
 }
 

--- a/humanitec-resource-defs/azure-service-bus-queue/basic/README.md
+++ b/humanitec-resource-defs/azure-service-bus-queue/basic/README.md
@@ -22,11 +22,10 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
+| driver\_account | The ID of the Resource Account which should be used. | `string` | n/a | yes |
 | resource\_group\_name | Specifies the Name of the Resource Group within which created resources will reside. | `string` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
+| append\_logs\_to\_error | Append Terraform logs to error messages. | `bool` | `false` | no |
 | name | Specifies the Name for created resources. (Leave empty for the default one) | `string` | `""` | no |
 | prefix | Specifies the prefix used in default name for created resources. | `string` | `"hum-rp-service-bus-ex-"` | no |
 | resource\_packs\_azure\_rev | Azure Resource Pack git branch. | `string` | `"refs/heads/main"` | no |

--- a/humanitec-resource-defs/azure-service-bus-queue/basic/main.tf
+++ b/humanitec-resource-defs/azure-service-bus-queue/basic/main.tf
@@ -4,19 +4,23 @@ resource "humanitec_resource_definition" "main" {
   name        = "${var.prefix}service-bus-basic"
   type        = "azure-service-bus-queue"
 
+  driver_account = var.driver_account
   driver_inputs = {
-    secrets_string = jsonencode({
-      variables = {
-        client_id     = var.client_id
-        client_secret = var.client_secret
-      }
-    })
-
     values_string = jsonencode({
       source = {
         path = "modules/azure-service-bus-queue/basic"
         rev  = var.resource_packs_azure_rev
         url  = var.resource_packs_azure_url
+      }
+
+      append_logs_to_error = var.append_logs_to_error
+
+      credentials_config = {
+        environment = {
+          ARM_CLIENT_ID     = "appId"
+          ARM_CLIENT_SECRET = "password"
+          ARM_TENANT_ID     = "tenant"
+        }
       }
 
       variables = {
@@ -25,7 +29,6 @@ resource "humanitec_resource_definition" "main" {
         env_id = "$${context.env.id}"
 
         name                = var.name
-        tenant_id           = var.tenant_id
         subscription_id     = var.subscription_id
         prefix              = var.prefix
         resource_group_name = var.resource_group_name

--- a/humanitec-resource-defs/azure-service-bus-queue/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/azure-service-bus-queue/basic/terraform.tfvars.example
@@ -1,9 +1,9 @@
 
-# The Client ID which should be used.
-client_id = ""
+# Append Terraform logs to error messages.
+append_logs_to_error = false
 
-# The Client Secret which should be used.
-client_secret = ""
+# The ID of the Resource Account which should be used.
+driver_account = ""
 
 # Specifies the Name for created resources. (Leave empty for the default one)
 name = ""
@@ -25,6 +25,3 @@ sku = "Standard"
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""

--- a/humanitec-resource-defs/azure-service-bus-queue/basic/variables.tf
+++ b/humanitec-resource-defs/azure-service-bus-queue/basic/variables.tf
@@ -10,18 +10,14 @@ variable "resource_packs_azure_rev" {
   default     = "refs/heads/main"
 }
 
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
+variable "append_logs_to_error" {
+  description = "Append Terraform logs to error messages."
+  type        = bool
+  default     = false
 }
 
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
+variable "driver_account" {
+  description = "The ID of the Resource Account which should be used."
   type        = string
 }
 

--- a/humanitec-resource-defs/dns/basic/README.md
+++ b/humanitec-resource-defs/dns/basic/README.md
@@ -22,13 +22,12 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
 | dns\_zone | The id of the hosted zone in which this record set will reside. | `string` | n/a | yes |
+| driver\_account | The ID of the Resource Account which should be used. | `string` | n/a | yes |
 | prefix | Prefix for all resources. | `string` | n/a | yes |
 | resource\_group\_name | Specifies the Name of the Resource Group within which this dns will reside. | `string` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
+| append\_logs\_to\_error | Append Terraform logs to error messages. | `bool` | `false` | no |
 | resource\_packs\_azure\_rev | Azure Resource Pack git branch. | `string` | `"refs/heads/main"` | no |
 | resource\_packs\_azure\_url | Azure Resource Pack git url. | `string` | `"https://github.com/humanitec-architecture/resource-packs-azure.git"` | no |
 

--- a/humanitec-resource-defs/dns/basic/main.tf
+++ b/humanitec-resource-defs/dns/basic/main.tf
@@ -4,19 +4,23 @@ resource "humanitec_resource_definition" "main" {
   name        = "${var.prefix}dns-basic"
   type        = "dns"
 
+  driver_account = var.driver_account
   driver_inputs = {
-    secrets_string = jsonencode({
-      variables = {
-        client_id     = var.client_id
-        client_secret = var.client_secret
-      }
-    })
-
     values_string = jsonencode({
       source = {
         path = "modules/dns/basic"
         rev  = var.resource_packs_azure_rev
         url  = var.resource_packs_azure_url
+      }
+
+      append_logs_to_error = var.append_logs_to_error
+
+      credentials_config = {
+        environment = {
+          ARM_CLIENT_ID     = "appId"
+          ARM_CLIENT_SECRET = "password"
+          ARM_TENANT_ID     = "tenant"
+        }
       }
 
       variables = {
@@ -25,7 +29,6 @@ resource "humanitec_resource_definition" "main" {
         env_id    = "$${context.env.id}"
         subdomain = "$${context.app.id}-$${context.env.id}"
 
-        tenant_id           = var.tenant_id
         subscription_id     = var.subscription_id
         dns_zone            = var.dns_zone
         resource_group_name = var.resource_group_name

--- a/humanitec-resource-defs/dns/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/dns/basic/terraform.tfvars.example
@@ -1,12 +1,12 @@
 
-# The Client ID which should be used.
-client_id = ""
-
-# The Client Secret which should be used.
-client_secret = ""
+# Append Terraform logs to error messages.
+append_logs_to_error = false
 
 # The id of the hosted zone in which this record set will reside.
 dns_zone = ""
+
+# The ID of the Resource Account which should be used.
+driver_account = ""
 
 # Prefix for all resources.
 prefix = ""
@@ -22,6 +22,3 @@ resource_packs_azure_url = "https://github.com/humanitec-architecture/resource-p
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""

--- a/humanitec-resource-defs/dns/basic/variables.tf
+++ b/humanitec-resource-defs/dns/basic/variables.tf
@@ -15,18 +15,14 @@ variable "resource_packs_azure_rev" {
   default     = "refs/heads/main"
 }
 
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
+variable "append_logs_to_error" {
+  description = "Append Terraform logs to error messages."
+  type        = bool
+  default     = false
 }
 
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
+variable "driver_account" {
+  description = "The ID of the Resource Account which should be used."
   type        = string
 }
 

--- a/humanitec-resource-defs/k8s/service-account/main.tf
+++ b/humanitec-resource-defs/k8s/service-account/main.tf
@@ -5,12 +5,6 @@ resource "humanitec_resource_definition" "main" {
 
   driver_type = "humanitec/template"
   driver_inputs = {
-    secrets_string = jsonencode({
-      templates = {
-        # outputs = ""
-      }
-    })
-
     values_string = jsonencode({
       templates = {
         # cookie    = ""

--- a/humanitec-resource-defs/mysql/basic/README.md
+++ b/humanitec-resource-defs/mysql/basic/README.md
@@ -24,14 +24,13 @@
 |------|-------------|------|---------|:--------:|
 | administrator\_login | The Administrator login for the MySQL Server. | `string` | n/a | yes |
 | administrator\_login\_password | The Password associated with the administrator\_login for the MySQL Server. | `string` | n/a | yes |
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
+| driver\_account | The ID of the Resource Account which should be used. | `string` | n/a | yes |
 | resource\_group\_name | Specifies the Name of the Resource Group within which this database will reside. | `string` | n/a | yes |
 | subnet\_name | The name of the Subnet from which Private IP Addresses will be allocated for this Private Endpoint. | `string` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
 | virtual\_network\_name | The name of the virtual network where Private Endpoint will be allocated. | `string` | n/a | yes |
 | virtual\_network\_resource\_group\_name | Specifies the Name of the Resource Group within which the Private Endpoint should exist. | `string` | n/a | yes |
+| append\_logs\_to\_error | Append Terraform logs to error messages. | `bool` | `false` | no |
 | auto\_grow\_enabled | Enable/Disable auto-growing of the storage. Storage auto-grow prevents your server from running out of storage and becoming read-only. | `bool` | `true` | no |
 | backup\_retention\_days | Backup retention days for the server, supported values are between 7 and 35 days. | `number` | `7` | no |
 | geo\_redundant\_backup\_enabled | Turn Geo-redundant server backups on/off. | `bool` | `true` | no |

--- a/humanitec-resource-defs/mysql/basic/main.tf
+++ b/humanitec-resource-defs/mysql/basic/main.tf
@@ -4,19 +4,23 @@ resource "humanitec_resource_definition" "main" {
   name        = "${var.prefix}mysql-basic"
   type        = "mysql"
 
+  driver_account = var.driver_account
   driver_inputs = {
-    secrets_string = jsonencode({
-      variables = {
-        client_id     = var.client_id
-        client_secret = var.client_secret
-      }
-    })
-
     values_string = jsonencode({
       source = {
         path = "modules/mysql/basic"
         rev  = var.resource_packs_azure_rev
         url  = var.resource_packs_azure_url
+      }
+
+      append_logs_to_error = var.append_logs_to_error
+
+      credentials_config = {
+        environment = {
+          ARM_CLIENT_ID     = "appId"
+          ARM_CLIENT_SECRET = "password"
+          ARM_TENANT_ID     = "tenant"
+        }
       }
 
       variables = {
@@ -27,7 +31,6 @@ resource "humanitec_resource_definition" "main" {
 
         name                                = var.name
         prefix                              = var.prefix
-        tenant_id                           = var.tenant_id
         subscription_id                     = var.subscription_id
         resource_group_name                 = var.resource_group_name
         administrator_login                 = var.administrator_login

--- a/humanitec-resource-defs/mysql/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/mysql/basic/terraform.tfvars.example
@@ -5,17 +5,17 @@ administrator_login = ""
 # The Password associated with the administrator_login for the MySQL Server.
 administrator_login_password = ""
 
+# Append Terraform logs to error messages.
+append_logs_to_error = false
+
 # Enable/Disable auto-growing of the storage. Storage auto-grow prevents your server from running out of storage and becoming read-only.
 auto_grow_enabled = true
 
 # Backup retention days for the server, supported values are between 7 and 35 days.
 backup_retention_days = 7
 
-# The Client ID which should be used.
-client_id = ""
-
-# The Client Secret which should be used.
-client_secret = ""
+# The ID of the Resource Account which should be used.
+driver_account = ""
 
 # Turn Geo-redundant server backups on/off.
 geo_redundant_backup_enabled = true
@@ -58,9 +58,6 @@ subnet_name = ""
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""
 
 # The name of the virtual network where Private Endpoint will be allocated.
 virtual_network_name = ""

--- a/humanitec-resource-defs/mysql/basic/variables.tf
+++ b/humanitec-resource-defs/mysql/basic/variables.tf
@@ -22,18 +22,14 @@ variable "resource_packs_azure_rev" {
   default     = "refs/heads/main"
 }
 
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
+variable "append_logs_to_error" {
+  description = "Append Terraform logs to error messages."
+  type        = bool
+  default     = false
 }
 
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
+variable "driver_account" {
+  description = "The ID of the Resource Account which should be used."
   type        = string
 }
 

--- a/humanitec-resource-defs/redis/basic/README.md
+++ b/humanitec-resource-defs/redis/basic/README.md
@@ -22,11 +22,10 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
+| driver\_account | The ID of the Resource Account which should be used. | `string` | n/a | yes |
 | resource\_group\_name | Specifies the Name of the Resource Group within which this database will reside. | `string` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
+| append\_logs\_to\_error | Append Terraform logs to error messages. | `bool` | `false` | no |
 | capacity | The size of the Redis cache to deploy. | `number` | `2` | no |
 | enable\_non\_ssl\_port | Enable the non-SSL port | `bool` | `false` | no |
 | family | The SKU family/pricing group to use. | `string` | `"C"` | no |

--- a/humanitec-resource-defs/redis/basic/main.tf
+++ b/humanitec-resource-defs/redis/basic/main.tf
@@ -4,19 +4,23 @@ resource "humanitec_resource_definition" "main" {
   name        = "${var.prefix}redis-basic"
   type        = "redis"
 
+  driver_account = var.driver_account
   driver_inputs = {
-    secrets_string = jsonencode({
-      variables = {
-        client_id     = var.client_id
-        client_secret = var.client_secret
-      }
-    })
-
     values_string = jsonencode({
       source = {
         path = "modules/redis/basic"
         rev  = var.resource_packs_azure_rev
         url  = var.resource_packs_azure_url
+      }
+
+      append_logs_to_error = var.append_logs_to_error
+
+      credentials_config = {
+        environment = {
+          ARM_CLIENT_ID     = "appId"
+          ARM_CLIENT_SECRET = "password"
+          ARM_TENANT_ID     = "tenant"
+        }
       }
 
       variables = {
@@ -25,7 +29,6 @@ resource "humanitec_resource_definition" "main" {
         env_id = "$${context.env.id}"
 
         name                = var.name
-        tenant_id           = var.tenant_id
         subscription_id     = var.subscription_id
         prefix              = var.prefix
         resource_group_name = var.resource_group_name

--- a/humanitec-resource-defs/redis/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/redis/basic/terraform.tfvars.example
@@ -1,12 +1,12 @@
 
+# Append Terraform logs to error messages.
+append_logs_to_error = false
+
 # The size of the Redis cache to deploy.
 capacity = 2
 
-# The Client ID which should be used.
-client_id = ""
-
-# The Client Secret which should be used.
-client_secret = ""
+# The ID of the Resource Account which should be used.
+driver_account = ""
 
 # Enable the non-SSL port
 enable_non_ssl_port = false
@@ -37,6 +37,3 @@ sku_name = "Standard"
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""

--- a/humanitec-resource-defs/redis/basic/variables.tf
+++ b/humanitec-resource-defs/redis/basic/variables.tf
@@ -10,18 +10,14 @@ variable "resource_packs_azure_rev" {
   default     = "refs/heads/main"
 }
 
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
+variable "append_logs_to_error" {
+  description = "Append Terraform logs to error messages."
+  type        = bool
+  default     = false
 }
 
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
+variable "driver_account" {
+  description = "The ID of the Resource Account which should be used."
   type        = string
 }
 

--- a/modules/azure-blob/basic/README.md
+++ b/modules/azure-blob/basic/README.md
@@ -25,14 +25,11 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | app\_id | n/a | `string` | n/a | yes |
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
 | container\_name | The name of the Container which should be created within the Storage Account. | `string` | n/a | yes |
 | env\_id | n/a | `string` | n/a | yes |
 | res\_id | n/a | `string` | n/a | yes |
 | resource\_group\_name | Specifies the Name of the Resource Group within which created resources will reside. | `string` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
 | account\_replication\_type | Defines the type of replication to use for this storage account. | `string` | `"GRS"` | no |
 | account\_tier | Defines the Tier to use for this storage account. | `string` | `"Standard"` | no |
 | container\_access\_type | The Access Level configured for this Container. | `string` | `"private"` | no |

--- a/modules/azure-blob/basic/provider.tf
+++ b/modules/azure-blob/basic/provider.tf
@@ -12,8 +12,5 @@ terraform {
 provider "azurerm" {
   features {}
 
-  client_id       = var.client_id
-  client_secret   = var.client_secret
-  tenant_id       = var.tenant_id
   subscription_id = var.subscription_id
 }

--- a/modules/azure-blob/basic/terraform.tfvars.example
+++ b/modules/azure-blob/basic/terraform.tfvars.example
@@ -7,12 +7,6 @@ account_tier = "Standard"
 
 app_id = ""
 
-# The Client ID which should be used.
-client_id = ""
-
-# The Client Secret which should be used.
-client_secret = ""
-
 # The Access Level configured for this Container.
 container_access_type = "private"
 
@@ -34,6 +28,3 @@ resource_group_name = ""
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""

--- a/modules/azure-blob/basic/variables.tf
+++ b/modules/azure-blob/basic/variables.tf
@@ -1,18 +1,3 @@
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
-}
-
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
-  type        = string
-}
-
 variable "subscription_id" {
   description = "The Subscription ID which should be used."
   type        = string

--- a/modules/azure-federated-identity/basic/README.md
+++ b/modules/azure-federated-identity/basic/README.md
@@ -24,8 +24,6 @@
 |------|-------------|------|---------|:--------:|
 | app\_id | n/a | `string` | n/a | yes |
 | audience | Specifies the audience for this Federated Identity Credential. | `set(string)` | n/a | yes |
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
 | env\_id | n/a | `string` | n/a | yes |
 | issuer | Specifies the issuer of this Federated Identity Credential. | `string` | n/a | yes |
 | parent\_id | Specifies parent ID of User Assigned Identity for this Federated Identity Credential. | `string` | n/a | yes |
@@ -33,7 +31,6 @@
 | resource\_group\_name | Specifies the Name of the Resource Group within which created resources will reside. | `string` | n/a | yes |
 | subject | Specifies the subject for this Federated Identity Credential. | `string` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
 | name | Specifies the Name for created resources. (Leave empty for the default one) | `string` | `""` | no |
 | prefix | Specifies the prefix used in default name for created resources. | `string` | `"hum-rp-mysql-ex-"` | no |
 

--- a/modules/azure-federated-identity/basic/provider.tf
+++ b/modules/azure-federated-identity/basic/provider.tf
@@ -12,8 +12,5 @@ terraform {
 provider "azurerm" {
   features {}
 
-  client_id       = var.client_id
-  client_secret   = var.client_secret
-  tenant_id       = var.tenant_id
   subscription_id = var.subscription_id
 }

--- a/modules/azure-federated-identity/basic/terraform.tfvars.example
+++ b/modules/azure-federated-identity/basic/terraform.tfvars.example
@@ -3,12 +3,6 @@ app_id = ""
 # Specifies the audience for this Federated Identity Credential.
 audience = ""
 
-# The Client ID which should be used.
-client_id = ""
-
-# The Client Secret which should be used.
-client_secret = ""
-
 env_id = ""
 
 # Specifies the issuer of this Federated Identity Credential.
@@ -33,6 +27,3 @@ subject = ""
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""

--- a/modules/azure-federated-identity/basic/variables.tf
+++ b/modules/azure-federated-identity/basic/variables.tf
@@ -1,18 +1,3 @@
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
-}
-
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
-  type        = string
-}
-
 variable "subscription_id" {
   description = "The Subscription ID which should be used."
   type        = string

--- a/modules/azure-managed-identity/basic/README.md
+++ b/modules/azure-managed-identity/basic/README.md
@@ -24,13 +24,10 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | app\_id | n/a | `string` | n/a | yes |
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
 | env\_id | n/a | `string` | n/a | yes |
 | res\_id | n/a | `string` | n/a | yes |
 | resource\_group\_name | Specifies the Name of the Resource Group within which created resources will reside. | `string` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
 | name | Specifies the Name for created resources. (Leave empty for the default one) | `string` | `""` | no |
 | prefix | Specifies the prefix used in default name for created resources. | `string` | `"hum-rp-mysql-ex-"` | no |
 

--- a/modules/azure-managed-identity/basic/provider.tf
+++ b/modules/azure-managed-identity/basic/provider.tf
@@ -12,8 +12,5 @@ terraform {
 provider "azurerm" {
   features {}
 
-  client_id       = var.client_id
-  client_secret   = var.client_secret
-  tenant_id       = var.tenant_id
   subscription_id = var.subscription_id
 }

--- a/modules/azure-managed-identity/basic/terraform.tfvars.example
+++ b/modules/azure-managed-identity/basic/terraform.tfvars.example
@@ -1,11 +1,4 @@
 app_id = ""
-
-# The Client ID which should be used.
-client_id = ""
-
-# The Client Secret which should be used.
-client_secret = ""
-
 env_id = ""
 
 # Specifies the Name for created resources. (Leave empty for the default one)
@@ -21,6 +14,3 @@ resource_group_name = ""
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""

--- a/modules/azure-managed-identity/basic/variables.tf
+++ b/modules/azure-managed-identity/basic/variables.tf
@@ -1,18 +1,3 @@
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
-}
-
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
-  type        = string
-}
-
 variable "subscription_id" {
   description = "The Subscription ID which should be used."
   type        = string

--- a/modules/azure-role-assignments/basic/README.md
+++ b/modules/azure-role-assignments/basic/README.md
@@ -22,13 +22,10 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
 | principal\_id | The ID of the Principal (User, Group or Service Principal) to assign the Role Definition to. | `string` | n/a | yes |
 | role\_definition\_ids | n/a | `any` | n/a | yes |
 | scopes | n/a | `any` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/azure-role-assignments/basic/provider.tf
+++ b/modules/azure-role-assignments/basic/provider.tf
@@ -12,8 +12,5 @@ terraform {
 provider "azurerm" {
   features {}
 
-  client_id       = var.client_id
-  client_secret   = var.client_secret
-  tenant_id       = var.tenant_id
   subscription_id = var.subscription_id
 }

--- a/modules/azure-role-assignments/basic/terraform.tfvars.example
+++ b/modules/azure-role-assignments/basic/terraform.tfvars.example
@@ -1,10 +1,4 @@
 
-# The Client ID which should be used.
-client_id = ""
-
-# The Client Secret which should be used.
-client_secret = ""
-
 # The ID of the Principal (User, Group or Service Principal) to assign the Role Definition to.
 principal_id = ""
 
@@ -13,6 +7,3 @@ scopes              = ""
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""

--- a/modules/azure-role-assignments/basic/variables.tf
+++ b/modules/azure-role-assignments/basic/variables.tf
@@ -1,18 +1,3 @@
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
-}
-
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
-  type        = string
-}
-
 variable "subscription_id" {
   description = "The Subscription ID which should be used."
   type        = string

--- a/modules/azure-role-definition/basic/README.md
+++ b/modules/azure-role-definition/basic/README.md
@@ -24,13 +24,10 @@
 |------|-------------|------|---------|:--------:|
 | actions | One or more Allowed Actions. | `set(string)` | n/a | yes |
 | app\_id | n/a | `string` | n/a | yes |
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
 | data\_actions | One or more Allowed Data Actions. | `set(string)` | n/a | yes |
 | env\_id | n/a | `string` | n/a | yes |
 | res\_id | n/a | `string` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
 | name | Specifies the Name for created resources. (Leave empty for the default one) | `string` | `""` | no |
 | prefix | Specifies the prefix used in default name for created resources. | `string` | `"hum-rp-mysql-ex-"` | no |
 | scope | The scope at which the Role Definition applies to. | `string` | `""` | no |

--- a/modules/azure-role-definition/basic/provider.tf
+++ b/modules/azure-role-definition/basic/provider.tf
@@ -12,8 +12,5 @@ terraform {
 provider "azurerm" {
   features {}
 
-  client_id       = var.client_id
-  client_secret   = var.client_secret
-  tenant_id       = var.tenant_id
   subscription_id = var.subscription_id
 }

--- a/modules/azure-role-definition/basic/terraform.tfvars.example
+++ b/modules/azure-role-definition/basic/terraform.tfvars.example
@@ -4,12 +4,6 @@ actions = ""
 
 app_id = ""
 
-# The Client ID which should be used.
-client_id = ""
-
-# The Client Secret which should be used.
-client_secret = ""
-
 # One or more Allowed Data Actions.
 data_actions = ""
 
@@ -28,6 +22,3 @@ scope = ""
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""

--- a/modules/azure-role-definition/basic/variables.tf
+++ b/modules/azure-role-definition/basic/variables.tf
@@ -1,18 +1,3 @@
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
-}
-
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
-  type        = string
-}
-
 variable "subscription_id" {
   description = "The Subscription ID which should be used."
   type        = string

--- a/modules/azure-service-bus-queue/basic/README.md
+++ b/modules/azure-service-bus-queue/basic/README.md
@@ -25,13 +25,10 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | app\_id | n/a | `string` | n/a | yes |
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
 | env\_id | n/a | `string` | n/a | yes |
 | res\_id | n/a | `string` | n/a | yes |
 | resource\_group\_name | Specifies the Name of the Resource Group within which created resources will reside. | `string` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
 | name | Specifies the Name for created resources. (Leave empty for the default one) | `string` | `""` | no |
 | prefix | Specifies the prefix used in default name for created resources. | `string` | `"hum-rp-service-bus-ex-"` | no |
 | sku | Defines which tier to use. | `string` | `"Standard"` | no |

--- a/modules/azure-service-bus-queue/basic/provider.tf
+++ b/modules/azure-service-bus-queue/basic/provider.tf
@@ -12,8 +12,5 @@ terraform {
 provider "azurerm" {
   features {}
 
-  client_id       = var.client_id
-  client_secret   = var.client_secret
-  tenant_id       = var.tenant_id
   subscription_id = var.subscription_id
 }

--- a/modules/azure-service-bus-queue/basic/terraform.tfvars.example
+++ b/modules/azure-service-bus-queue/basic/terraform.tfvars.example
@@ -1,11 +1,4 @@
 app_id = ""
-
-# The Client ID which should be used.
-client_id = ""
-
-# The Client Secret which should be used.
-client_secret = ""
-
 env_id = ""
 
 # Specifies the Name for created resources. (Leave empty for the default one)
@@ -24,6 +17,3 @@ sku = "Standard"
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""

--- a/modules/azure-service-bus-queue/basic/variables.tf
+++ b/modules/azure-service-bus-queue/basic/variables.tf
@@ -1,18 +1,3 @@
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
-}
-
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
-  type        = string
-}
-
 variable "subscription_id" {
   description = "The Subscription ID which should be used."
   type        = string

--- a/modules/dns/basic/README.md
+++ b/modules/dns/basic/README.md
@@ -26,15 +26,12 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | app\_id | n/a | `string` | n/a | yes |
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
 | dns\_zone | The id of the hosted zone in which this record set will reside. | `string` | n/a | yes |
 | env\_id | n/a | `string` | n/a | yes |
 | res\_id | n/a | `string` | n/a | yes |
 | resource\_group\_name | Specifies the Name of the Resource Group within which created resource will reside. | `string` | n/a | yes |
 | subdomain | The subdomain of the DNS name that the DNS record is for. | `string` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
 | ip\_address | The IPv4 address that the DNS name should resolve to. | `string` | `""` | no |
 | ipv6\_address | The IPv6 address that the DNS name should resolve to. | `string` | `""` | no |
 | name | A valid fully qualified domain name that the DNS name should resolve to. | `string` | `""` | no |

--- a/modules/dns/basic/provider.tf
+++ b/modules/dns/basic/provider.tf
@@ -12,8 +12,5 @@ terraform {
 provider "azurerm" {
   features {}
 
-  client_id       = var.client_id
-  client_secret   = var.client_secret
-  tenant_id       = var.tenant_id
   subscription_id = var.subscription_id
 }

--- a/modules/dns/basic/terraform.tfvars.example
+++ b/modules/dns/basic/terraform.tfvars.example
@@ -1,11 +1,5 @@
 app_id = ""
 
-# The Client ID which should be used.
-client_id = ""
-
-# The Client Secret which should be used.
-client_secret = ""
-
 # The id of the hosted zone in which this record set will reside.
 dns_zone = ""
 
@@ -30,6 +24,3 @@ subdomain = ""
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""

--- a/modules/dns/basic/variables.tf
+++ b/modules/dns/basic/variables.tf
@@ -1,19 +1,3 @@
-
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
-}
-
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
-  type        = string
-}
-
 variable "subscription_id" {
   description = "The Subscription ID which should be used."
   type        = string

--- a/modules/mysql/basic/README.md
+++ b/modules/mysql/basic/README.md
@@ -32,8 +32,6 @@
 | app\_id | n/a | `string` | n/a | yes |
 | auto\_grow\_enabled | Enable/Disable auto-growing of the storage. Storage auto-grow prevents your server from running out of storage and becoming read-only. | `bool` | n/a | yes |
 | backup\_retention\_days | Backup retention days for the server, supported values are between 7 and 35 days. | `number` | n/a | yes |
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
 | database\_name | Specifies the name for the created database | `string` | n/a | yes |
 | env\_id | n/a | `string` | n/a | yes |
 | geo\_redundant\_backup\_enabled | Turn Geo-redundant server backups on/off. | `bool` | n/a | yes |
@@ -47,7 +45,6 @@
 | storage\_mb | Max storage allowed for a server. | `number` | n/a | yes |
 | subnet\_name | The name of the Subnet from which Private IP Addresses will be allocated for this Private Endpoint. | `string` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
 | virtual\_network\_name | The name of the virtual network where Private Endpoint will be allocated. | `string` | n/a | yes |
 | virtual\_network\_resource\_group\_name | Specifies the Name of the Resource Group within which the Private Endpoint should exist. | `string` | n/a | yes |
 | name | Specifies the Name for created resources. (Leave empty for the default one) | `string` | `""` | no |

--- a/modules/mysql/basic/provider.tf
+++ b/modules/mysql/basic/provider.tf
@@ -12,8 +12,5 @@ terraform {
 provider "azurerm" {
   features {}
 
-  client_id       = var.client_id
-  client_secret   = var.client_secret
-  tenant_id       = var.tenant_id
   subscription_id = var.subscription_id
 }

--- a/modules/mysql/basic/terraform.tfvars.example
+++ b/modules/mysql/basic/terraform.tfvars.example
@@ -13,12 +13,6 @@ auto_grow_enabled = ""
 # Backup retention days for the server, supported values are between 7 and 35 days.
 backup_retention_days = ""
 
-# The Client ID which should be used.
-client_id = ""
-
-# The Client Secret which should be used.
-client_secret = ""
-
 # Specifies the name for the created database
 database_name = ""
 
@@ -61,9 +55,6 @@ subnet_name = ""
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""
 
 # The name of the virtual network where Private Endpoint will be allocated.
 virtual_network_name = ""

--- a/modules/mysql/basic/variables.tf
+++ b/modules/mysql/basic/variables.tf
@@ -1,19 +1,3 @@
-
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
-}
-
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
-  type        = string
-}
-
 variable "subscription_id" {
   description = "The Subscription ID which should be used."
   type        = string

--- a/modules/redis/basic/README.md
+++ b/modules/redis/basic/README.md
@@ -24,13 +24,10 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | app\_id | n/a | `string` | n/a | yes |
-| client\_id | The Client ID which should be used. | `string` | n/a | yes |
-| client\_secret | The Client Secret which should be used. | `string` | n/a | yes |
 | env\_id | n/a | `string` | n/a | yes |
 | res\_id | n/a | `string` | n/a | yes |
 | resource\_group\_name | Specifies the Name of the Resource Group within which created resources will reside. | `string` | n/a | yes |
 | subscription\_id | The Subscription ID which should be used. | `string` | n/a | yes |
-| tenant\_id | The Tenant ID which should be used. | `string` | n/a | yes |
 | capacity | The size of the Redis cache to deploy. | `number` | `2` | no |
 | enable\_non\_ssl\_port | Enable the non-SSL port | `bool` | `false` | no |
 | family | The SKU family/pricing group to use. | `string` | `"C"` | no |

--- a/modules/redis/basic/provider.tf
+++ b/modules/redis/basic/provider.tf
@@ -12,8 +12,5 @@ terraform {
 provider "azurerm" {
   features {}
 
-  client_id       = var.client_id
-  client_secret   = var.client_secret
-  tenant_id       = var.tenant_id
   subscription_id = var.subscription_id
 }

--- a/modules/redis/basic/terraform.tfvars.example
+++ b/modules/redis/basic/terraform.tfvars.example
@@ -3,12 +3,6 @@ app_id = ""
 # The size of the Redis cache to deploy.
 capacity = 2
 
-# The Client ID which should be used.
-client_id = ""
-
-# The Client Secret which should be used.
-client_secret = ""
-
 # Enable the non-SSL port
 enable_non_ssl_port = false
 
@@ -36,6 +30,3 @@ sku_name = "Standard"
 
 # The Subscription ID which should be used.
 subscription_id = ""
-
-# The Tenant ID which should be used.
-tenant_id = ""

--- a/modules/redis/basic/variables.tf
+++ b/modules/redis/basic/variables.tf
@@ -1,18 +1,3 @@
-variable "client_id" {
-  description = "The Client ID which should be used."
-  type        = string
-}
-
-variable "client_secret" {
-  description = "The Client Secret which should be used."
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Tenant ID which should be used."
-  type        = string
-}
-
 variable "subscription_id" {
   description = "The Subscription ID which should be used."
   type        = string


### PR DESCRIPTION
Use [Resource Account](https://developer.humanitec.com/platform-orchestrator/security/cloud-accounts/) to configure the Azure credentials, which will simplify adopting temporary credentials in the future.

Also move account creating into the examples, to showcase the permissions needed. At the moment those are fairly broad (`Contributor` in the resource group), but will be trimmed down as a follow-up.

As Terraform logs are often useful for debugging, support enabling/disable `append_logs_to_error` in all definitions.